### PR TITLE
LGTM画像をPNGからWebP形式に変換する処理を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ lgtm-cat（サービス名 LGTMeow https://lgtmeow.com のバックエンド用
 ## 環境
 - Go v1.15
 - S3にファイルをアップロードするため、AWS 名前付きプロファイルが設定されていること(プロファイル名: `lgtm-cat`)
+- [webp](https://formulae.brew.sh/formula/webp) ( cwebp を実行できること )
 
 ## LGTM画像の作成方法
 

--- a/generate_lgtm_images.sh
+++ b/generate_lgtm_images.sh
@@ -2,8 +2,24 @@
 
 set -ex
 
+# LGTM画像用のディレクトリを作成
+mkdir -p lgtm_image
+
 # goを実行する
 go run cmd/generateLgtmImage/main.go
+
+# ./lgtm_image に出力されたPNG形式のLGTM画像をWebPに変換
+cd lgtm_image
+array=`\find . -mindepth 1 -maxdepth 1 -type f`
+for fpath in $array; do
+    fname_ext="${fpath##*/}"
+    fname="${fname_ext%.*}"
+    cwebp -lossless -metadata icc -o $fname.webp $fname.png
+done
+
+# 不要になった ./lgtm_image ディレクトリのpngの画像を削除
+rm *.png
+cd ../
 
 # /image の中身を /completeImage に移動
 mkdir -p complete_image


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-backend/issues/1

# Doneの定義
- LGTM画像の形式がWebPに変換できること

# 変更点概要
- LGTM画像を作成するスクリプトに、LGTM画像をPNGからWebP形式に変換する処理を追加
- S3にアップロードされ、ブラウザから表示されることを確認
https://lgtm-images.lgtmeow.com/2021/03/10/01/deb0eaea-f08f-46f3-972a-9b1290df9781.webp

<img width="518" alt="スクリーンショット 2021-03-10 2 02 35" src="https://user-images.githubusercontent.com/32682645/110508897-df5b6480-8144-11eb-847f-0916b1a77c73.png">